### PR TITLE
Implement support for url-based middleware

### DIFF
--- a/packages/middleware-compiler/README.md
+++ b/packages/middleware-compiler/README.md
@@ -16,7 +16,10 @@ Webtask middleware are disigned in a [connect](https://github.com/senchalabs/con
 
 2. Set the `wt-compiler` metadata property on your webtask to `@webtask/middleware-compiler`.
 
-3. *Optionally*, set the `wt-middleware` metadata property to a comma-separated list of middleware references. These references can be the name of an npm module, in which case the module's default export is used. These can also be references like `module_name/name_of_export_function`, which would be equivalent to `require('module_name').name_of_export_function`. These middleware will be invoked sequentially and the next middleware will only be invoked if the previous middleware calls `next()` without argument.
+3. *Optionally*, set the `wt-middleware` metadata property to a comma-separated list of middleware references. Middleware references can be any combination of:
+    - `module_name` - The name of an npm module, in which case the module's default export is used. This would be equivalent to `require('module_name')`.
+    - `module_name/name_of_export_function` - The name of an npm module with the name of the desired export. This wouldbe equivalent to `require('module_name').name_of_export_function`.
+    - `http(s)://url.of/a/file/exporting/a/middleware.js` - A publicly accessible url from which the middleware's code will be downloaded and evaluated. The code must export a suitable middleware factory function as the default export.
 
 3. *Optionally*, set the `wt-debug` metadata property to a comma-separated list of debug references that contains `wt-middleware`. This will result in additional debug information being sent to real-time logs.
 

--- a/packages/middleware-compiler/lib/util.js
+++ b/packages/middleware-compiler/lib/util.js
@@ -1,10 +1,16 @@
 'use strict';
 
 const MIDDLEWARE_SPEC_RX = /^(@[^/(]+\/[^/(]+|[^@/(]+)(?:\/([^/(]+))?$/;
+const URL_MIDDLEWARE_MAX_REDIRECTS = 5;
+const URL_MIDDLEWARE_RX = /^https?:\/\//;
+const URL_MIDDLEWARE_TIMEOUT = 2000;
+
+let Wreck;
 
 module.exports = {
     parseMiddlewareSpecString,
-    resolveCompiler,
+    resolveMiddlewareFunction,
+    validateMiddlewareFunction,
 };
 
 /**
@@ -33,18 +39,111 @@ function parseMiddlewareSpecString(spec) {
  * @param {object} options Options
  * @returns {function}
  */
-function resolveCompiler(spec) {
+function resolveMiddlewareFunction(spec, { debuglog, nodejsCompiler }, cb) {
     // Already a function, no resolution to do.
-    if (typeof spec === 'function') return spec;
+    if (typeof spec !== 'string') {
+        return process.nextTick(cb, new Error('Unexpected spec type'));
+    }
 
-    const parsedSpec = parseMiddlewareSpecString(spec);
-    const module = require(parsedSpec.moduleName);
-    const middlewareFn = parsedSpec.exportName
-        ? module[parsedSpec.exportName]()
-        : module();
+    if (URL_MIDDLEWARE_RX.test(spec)) {
+        return resolveUrlMiddlewareFunction(
+            spec,
+            { debuglog, nodejsCompiler },
+            cb
+        );
+    }
 
+    return resolveNpmMiddlewareFunction(spec, { debuglog }, cb);
+}
+/**
+ * Resolve an npm-based middleware specification into a middleware function
+ *
+ * @param {string} spec NPM middleware spec
+ * @param {object} options Options
+ * @param {function} cb Callback
+ */
+function resolveNpmMiddlewareFunction(spec, { debuglog }, cb) {
+    debuglog('resolving an npm module middleware "%s"'.spec);
+
+    try {
+        const parsedSpec = parseMiddlewareSpecString(spec);
+        const module = require(parsedSpec.moduleName);
+        const middlewareFn = parsedSpec.exportName
+            ? module[parsedSpec.exportName]()
+            : module();
+
+        return process.nextTick(
+            cb,
+            null,
+            validateMiddlewareFunction(middlewareFn)
+        );
+    } catch (error) {
+        return process.nextTick(cb, error);
+    }
+}
+
+/**
+ * Resolve a url-based middleware specification into a middleware function
+ *
+ * @param {string} url Url of the middleware code
+ * @param {object} options Options
+ * @param {function} cb Callback
+ */
+function resolveUrlMiddlewareFunction(url, { debuglog, nodejsCompiler }, cb) {
+    if (!Wreck) Wreck = require('wreck');
+
+    const wreckOptions = {
+        redirects: URL_MIDDLEWARE_MAX_REDIRECTS,
+        timeout: URL_MIDDLEWARE_TIMEOUT,
+    };
+
+    return Wreck.get(url, wreckOptions, (error, response, payload) => {
+        if (error) {
+            debuglog(
+                'Error fetching middleware from "%s": $s',
+                url,
+                error.message
+            );
+
+            return cb(error);
+        }
+
+        const middlewareCode = payload.toString('utf-8');
+
+        return nodejsCompiler(middlewareCode, (error, middlewareFn) => {
+            if (error) {
+                debuglog('Error compiling webtask code: %s', error.stack);
+
+                return cb(error);
+            }
+
+            try {
+                validateMiddlewareFunction(middlewareFn);
+            } catch (e) {
+                debuglog(
+                    'The code at "%s", when compiled, exported an invalid middlware function: %s',
+                    url,
+                    e.message
+                );
+
+                return cb(e);
+            }
+
+            return cb(null, middlewareFn);
+        });
+    });
+}
+
+/**
+ * Validate a middleware function
+ *
+ * @param {function} middlewareFn A middleware function to be validated
+ */
+function validateMiddlewareFunction(middlewareFn) {
     if (typeof middlewareFn !== 'function' || middlewareFn.length !== 3) {
-        throw new Error('A Webtask middleware must export a function that returns a function with the signature `function(req, res, next)`');
+        throw new Error(
+            'A Webtask middleware must export a function that returns a function with the signature `function(req, res, next)`'
+        );
     }
 
     return middlewareFn;

--- a/packages/middleware-compiler/package.json
+++ b/packages/middleware-compiler/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "lab -vL"
+    "test": "lab -cvL -t 90"
   },
   "keywords": [],
   "author": "Geoff Goodman (https://github.com/ggoodman)",
@@ -16,6 +16,9 @@
     "wreck": "^12.2.3"
   },
   "devDependencies": {
-    "lab": "^14.2.0"
+    "@webtask/bearer-auth-middleware": "^1.1.1",
+    "body-parser": "^1.17.2",
+    "lab": "^14.2.0",
+    "shot": "^3.4.2"
   }
 }

--- a/packages/middleware-compiler/test/lib/helpers.js
+++ b/packages/middleware-compiler/test/lib/helpers.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const Compiler = require('../../');
+const Http = require('http');
+const Module = require('module');
+const Shot = require('shot');
+const Vm = require('vm');
+
+module.exports = {
+    createPipeline,
+    invokePipeline,
+    nodejsCompiler,
+    spawnServer,
+};
+
+function createPipeline({ script, middlewareSpecs }, cb) {
+    const meta = {
+        'wt-middleware': middlewareSpecs.join(','),
+    };
+    const compilerOptions = {
+        meta,
+        nodejsCompiler,
+        script,
+    };
+
+    return Compiler(compilerOptions, cb);
+}
+
+function invokePipeline(
+    webtaskFn,
+    { headers = {}, method = 'GET', payload, secrets = {}, url = '/' },
+    cb
+) {
+    const dispatchFn = (req, res) => {
+        const webtaskContext = {
+            secrets,
+            headers: req.headers,
+        };
+
+        return webtaskFn(webtaskContext, req, res);
+    };
+    const requestOptions = { headers, method, payload, url };
+
+    return Shot.inject(dispatchFn, requestOptions, cb);
+}
+
+function nodejsCompiler(script, cb) {
+    try {
+        const wrapper = Module.wrap(script);
+        const wrapperFn = Vm.runInNewContext(wrapper);
+        const exports = {};
+        const module = { exports };
+
+        wrapperFn(exports, require, module, 'middleware.js', '/');
+
+        return process.nextTick(cb, null, module.exports);
+    } catch (e) {
+        return process.nextTick(cb, e);
+    }
+}
+
+function spawnServer(handler, cb) {
+    const handlerFn =
+        typeof handler === 'function'
+            ? handler
+            : (req, res) => {
+                  res.writeHead(200);
+                  res.end(handler);
+              };
+    const server = Http.createServer(handlerFn);
+
+    return server.listen(error => {
+        if (error) {
+            return cb(error);
+        }
+
+        const baseUrl = `http://localhost:${server.address().port}`;
+
+        return cb(null, { baseUrl, stop });
+
+        // Return a clean-up function
+        function stop(cb) {
+            return server.close(cb);
+        }
+    });
+}

--- a/packages/middleware-compiler/test/operation.js
+++ b/packages/middleware-compiler/test/operation.js
@@ -1,0 +1,503 @@
+'use strict';
+
+const Assert = require('assert');
+const Compiler = require('../');
+const Helpers = require('./lib/helpers');
+const Lab = require('lab');
+
+const lab = Lab.script();
+const { describe, it } = lab;
+
+module.exports = { lab };
+
+describe('middleware compiler operation', { parallel: true }, () => {
+    const nodejsCompiler = Helpers.nodejsCompiler;
+
+    it('succeeds in producing a webtask function', done => {
+        const script = `module.exports = cb => cb(null, 'OK');`;
+        const meta = {};
+        const compilerOptions = {
+            meta,
+            nodejsCompiler,
+            script,
+        };
+
+        return Compiler(compilerOptions, (error, webtaskFn) => {
+            Assert.ifError(error);
+            Assert.equal(typeof webtaskFn, 'function');
+
+            done();
+        });
+    });
+
+    it('succeeds in producing a webtask function with a middleware', done => {
+        const script = `module.exports = cb => cb(null, 'OK');`;
+        const meta = {
+            'wt-middleware': '@webtask/bearer-auth-middleware',
+        };
+        const compilerOptions = {
+            meta,
+            nodejsCompiler,
+            script,
+        };
+
+        return Compiler(compilerOptions, (error, webtaskFn) => {
+            Assert.ifError(error);
+            Assert.equal(typeof webtaskFn, 'function');
+
+            done();
+        });
+    });
+
+    it('succeeds in producing a webtask function with a middleware and enables debug logging', done => {
+        const script = `module.exports = cb => cb(null, 'OK');`;
+        const meta = {
+            'wt-debug': 'wt-middleware',
+            'wt-middleware': '@webtask/bearer-auth-middleware',
+        };
+        const compilerOptions = {
+            meta,
+            nodejsCompiler,
+            script,
+        };
+
+        return Compiler(compilerOptions, (error, webtaskFn) => {
+            Assert.ifError(error);
+            Assert.equal(typeof webtaskFn, 'function');
+
+            done();
+        });
+    });
+
+    it('succeeds in producing a webtask function with a middleware specified as JSON', done => {
+        const script = `module.exports = cb => cb(null, 'OK');`;
+        const meta = {
+            'wt-middleware': JSON.stringify([
+                '@webtask/bearer-auth-middleware',
+            ]),
+        };
+        const compilerOptions = {
+            meta,
+            nodejsCompiler,
+            script,
+        };
+
+        return Compiler(compilerOptions, (error, webtaskFn) => {
+            Assert.ifError(error);
+            Assert.equal(typeof webtaskFn, 'function');
+
+            done();
+        });
+    });
+
+    it('fails to produce a webtask function with a middleware specified as JSON that is not a valid array', done => {
+        const script = `module.exports = cb => cb(null, 'OK');`;
+        const meta = {
+            'wt-middleware': JSON.stringify({
+                wrong: '@webtask/bearer-auth-middleware',
+            }),
+        };
+        const compilerOptions = {
+            meta,
+            nodejsCompiler,
+            script,
+        };
+
+        return Compiler(compilerOptions, (error, webtaskFn) => {
+            Assert.ok(error);
+            Assert.equal(typeof webtaskFn, 'undefined');
+
+            done();
+        });
+    });
+
+    describe('pipeline execution', { parallel: true }, () => {
+        const createPipeline = Helpers.createPipeline;
+        const invokePipeline = Helpers.invokePipeline;
+
+        it('responds with an error when the underlying webtask code is invalid javascript', done => {
+            const script = `module.exports = this is how it works, right?`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 500);
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('responds with an error when the underlying webtask exports a method that does not conform to the webtask programming model', done => {
+            const script = `module.exports = (ctx, req, res, giraffe) => giraffe()`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 500);
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('handles a non-Error error argument in the callback when running a 1ary webtask without middleware', done => {
+            const script = `module.exports = cb => cb('Oops');`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 500);
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('handles objects that cannot be stringified that are passed to the callback when running a 1ary webtask without middleware', done => {
+            const script = `module.exports = cb => { const recurse = {}; recurse.recurse = recurse; cb(null, recurse); }`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 500);
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('succeeds in running a 1ary webtask without middleware', done => {
+            const script = `module.exports = cb => cb(null, 'OK');`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 200);
+                        Assert.equal(res.payload, '"OK"');
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('succeeds in running a 1ary webtask without middleware twice in sequence', done => {
+            const script = `module.exports = cb => cb(null, 'OK');`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 200);
+                        Assert.equal(res.payload, '"OK"');
+
+                        return invokePipeline(webtaskFn, {}, res => {
+                            Assert.equal(res.statusCode, 200);
+                            Assert.equal(res.payload, '"OK"');
+
+                            done();
+                        });
+                    });
+                }
+            );
+        });
+
+        it('succeeds in running a 2ary webtask without middleware', done => {
+            const script = `module.exports = (ctx, cb) => cb(null, 'OK');`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 200);
+                        Assert.equal(res.payload, '"OK"');
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('succeeds in running a 1ary webtask with a payload body, but without middleware', done => {
+            const script = `module.exports = (ctx, cb) => cb(null, ctx.body);`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    const method = 'POST';
+                    const payload = { json: 'body' };
+
+                    return invokePipeline(
+                        webtaskFn,
+                        { method, payload },
+                        res => {
+                            Assert.equal(res.statusCode, 200);
+                            Assert.equal(res.payload, JSON.stringify(payload));
+
+                            done();
+                        }
+                    );
+                }
+            );
+        });
+
+        it('succeeds in running a 2ary webtask with a payload body, but without middleware', done => {
+            const script = `module.exports = (ctx, cb) => cb(null, ctx.body);`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    const method = 'POST';
+                    const payload = { json: 'body' };
+
+                    return invokePipeline(
+                        webtaskFn,
+                        { method, payload },
+                        res => {
+                            Assert.equal(res.statusCode, 200);
+                            Assert.equal(res.payload, JSON.stringify(payload));
+
+                            done();
+                        }
+                    );
+                }
+            );
+        });
+
+        it('responds with an error when running a 2ary webtask with an invalid payload body, but without middleware', done => {
+            const script = `module.exports = (ctx, cb) => cb(null, ctx.body);`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    const headers = {
+                        'Content-Type': 'application/json',
+                    };
+                    const method = 'POST';
+                    const payload = 'this is not the json you were looking for';
+
+                    return invokePipeline(
+                        webtaskFn,
+                        { headers, method, payload },
+                        res => {
+                            Assert.equal(res.statusCode, 500);
+
+                            done();
+                        }
+                    );
+                }
+            );
+        });
+
+        it('succeeds in running a 3ary webtask with a payload body, with the bodyParser.json middleware', done => {
+            const script = `module.exports = (ctx, req, res) => { res.writeHead(200, { 'Content-Type': 'application-json' }); res.end(JSON.stringify(req.body)); };`;
+            const middlewareSpecs = ['body-parser/json'];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    const headers = {
+                        'Content-Type': 'application/json',
+                    };
+                    const method = 'POST';
+                    const payload = { json: 'body' };
+
+                    return invokePipeline(
+                        webtaskFn,
+                        { headers, method, payload },
+                        res => {
+                            Assert.equal(res.statusCode, 200);
+                            Assert.equal(res.payload, JSON.stringify(payload));
+
+                            done();
+                        }
+                    );
+                }
+            );
+        });
+
+        it('succeeds in running a 3ary webtask without middleware', done => {
+            const script = `module.exports = (ctx, req, res) => { res.writeHead(200); res.end('OK'); };`;
+            const middlewareSpecs = [];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 200);
+                        Assert.equal(res.payload, 'OK');
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('succeeds in running a webtask with middleware', done => {
+            const script = `module.exports = cb => cb(null, 'OK');`;
+            const middlewareSpecs = ['@webtask/bearer-auth-middleware'];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    return invokePipeline(webtaskFn, {}, res => {
+                        Assert.equal(res.statusCode, 200);
+                        Assert.equal(res.payload, '"OK"');
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it('succeeds in running a webtask with middleware that intercepts the response', done => {
+            const script = `module.exports = cb => cb(null, 'OK');`;
+            const middlewareSpecs = ['@webtask/bearer-auth-middleware'];
+
+            return createPipeline(
+                { script, middlewareSpecs },
+                (error, webtaskFn) => {
+                    Assert.ifError(error);
+
+                    const secrets = {
+                        'wt-auth-secret': 'secret',
+                    };
+
+                    return invokePipeline(webtaskFn, { secrets }, res => {
+                        Assert.equal(res.statusCode, 401);
+
+                        done();
+                    });
+                }
+            );
+        });
+
+        it(
+            'succeeds in running a webtask with a url-based middleware that passes on the response',
+            (done, onCleanup) => {
+                const script = `module.exports = cb => cb(null, 'OK');`;
+                const middleware = `
+                    module.exports = (req, res, next) => next();
+                `;
+                return Helpers.spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanup(server.stop);
+
+                    const middlewareSpecs = [server.baseUrl];
+
+                    return createPipeline(
+                        { script, middlewareSpecs },
+                        (error, webtaskFn) => {
+                            Assert.ifError(error);
+
+                            const secrets = {
+                                'wt-auth-secret': 'secret',
+                            };
+
+                            return invokePipeline(
+                                webtaskFn,
+                                { secrets },
+                                res => {
+                                    Assert.equal(res.statusCode, 200);
+                                    Assert.equal(res.payload, '"OK"');
+
+                                    done();
+                                }
+                            );
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'succeeds in running a webtask with a url-based middleware that intercepts on the response',
+            (done, onCleanup) => {
+                const script = `module.exports = cb => cb(null, 'OK');`;
+                const middleware = `
+                    module.exports = (req, res, next) => { res.writeHead(200); res.end('MIDDLEWARE'); };
+                `;
+                return Helpers.spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanup(server.stop);
+
+                    const middlewareSpecs = [server.baseUrl];
+
+                    return createPipeline(
+                        { script, middlewareSpecs },
+                        (error, webtaskFn) => {
+                            Assert.ifError(error);
+
+                            const secrets = {
+                                'wt-auth-secret': 'secret',
+                            };
+
+                            return invokePipeline(
+                                webtaskFn,
+                                { secrets },
+                                res => {
+                                    Assert.equal(res.statusCode, 200);
+                                    Assert.equal(res.payload, 'MIDDLEWARE');
+
+                                    done();
+                                }
+                            );
+                        }
+                    );
+                });
+            }
+        );
+    });
+});
+
+if (require.main === module) {
+    Lab.report([lab], { output: process.stdout, progress: 2 });
+}

--- a/packages/middleware-compiler/test/spec_loader.js
+++ b/packages/middleware-compiler/test/spec_loader.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const Assert = require('assert');
+const Helpers = require('./lib/helpers');
+const Lab = require('lab');
+const Util = require('../lib/util');
+
+const lab = Lab.script();
+const { describe, it } = lab;
+
+module.exports = { lab };
+
+describe('middleware spec loader', { parallel: true }, () => {
+    const debuglog = () => undefined;
+    const nodejsCompiler = Helpers.nodejsCompiler;
+
+    it('fails to load a non-string spec', done => {
+        return Util.resolveMiddlewareFunction(
+            123456,
+            { debuglog, nodejsCompiler },
+            (error, middlewareFn) => {
+                Assert.ok(error);
+                Assert.equal(middlewareFn, undefined);
+
+                done();
+            }
+        );
+    });
+
+    describe('module specs', { parallel: true }, () => {
+        it('succeeds loading an npm middleware function', done => {
+            return Util.resolveMiddlewareFunction(
+                '@webtask/bearer-auth-middleware',
+                { debuglog, nodejsCompiler },
+                (error, middlewareFn) => {
+                    Assert.ifError(error);
+                    Assert.equal(typeof middlewareFn, 'function');
+
+                    done();
+                }
+            );
+        });
+
+        it('succeeds loading an npm middleware function via export', done => {
+            return Util.resolveMiddlewareFunction(
+                'body-parser/json',
+                { debuglog, nodejsCompiler },
+                (error, middlewareFn) => {
+                    Assert.ifError(error);
+                    Assert.equal(typeof middlewareFn, 'function');
+
+                    done();
+                }
+            );
+        });
+
+        it('fails to load a module that is not available', done => {
+            return Util.resolveMiddlewareFunction(
+                '@webtask/this-will-never-exist',
+                { debuglog, nodejsCompiler },
+                (error, middlewareFn) => {
+                    Assert.ok(error);
+                    Assert.equal(middlewareFn, undefined);
+
+                    done();
+                }
+            );
+        });
+    });
+
+    describe('url specs', { parallel: true }, () => {
+        const spawnServer = Helpers.spawnServer;
+
+        it(
+            'succeeds loading a middleware function from a url',
+            (done, onCleanUp) => {
+                const middleware = `
+                    module.exports = (req, res, next) => next();
+                `;
+                return spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanUp(server.stop);
+
+                    const middlewareSpec = server.baseUrl;
+
+                    return Util.resolveMiddlewareFunction(
+                        middlewareSpec,
+                        { debuglog, nodejsCompiler },
+                        (error, middlewareFn) => {
+                            Assert.ifError(error);
+                            Assert.equal(typeof middlewareFn, 'function');
+
+                            return done();
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'fails to load a middleware function from a url whose code does not export a valid middleware function',
+            (done, onCleanUp) => {
+                const middleware = `
+                    module.exports = 'NOT A FUNCTION, JOE. DEFINITELY NOT A FUNCTION.';
+                `;
+                return spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanUp(server.stop);
+
+                    const middlewareSpec = server.baseUrl;
+
+                    return Util.resolveMiddlewareFunction(
+                        middlewareSpec,
+                        { debuglog, nodejsCompiler },
+                        (error, middlewareFn) => {
+                            Assert.ok(error);
+                            Assert.equal(middlewareFn, undefined);
+
+                            return done();
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'fails to load a middleware function from a url whose code is not valid javascript',
+            (done, onCleanUp) => {
+                const middleware = `
+                    module.exports = can has cheezburger?;
+                `;
+                return spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanUp(server.stop);
+
+                    const middlewareSpec = server.baseUrl;
+
+                    return Util.resolveMiddlewareFunction(
+                        middlewareSpec,
+                        { debuglog, nodejsCompiler },
+                        (error, middlewareFn) => {
+                            Assert.ok(error);
+                            Assert.equal(middlewareFn, undefined);
+
+                            return done();
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'fails to load an middleware from a url returning a 404 error',
+            (done, onCleanUp) => {
+                const handler = (req, res) => {
+                    res.writeHead(404);
+                    res.end();
+                };
+                return spawnServer(handler, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanUp(server.stop);
+
+                    const middlewareSpec = server.baseUrl;
+
+                    return Util.resolveMiddlewareFunction(
+                        middlewareSpec,
+                        { debuglog, nodejsCompiler },
+                        (error, middlewareFn) => {
+                            Assert.ok(error);
+                            Assert.equal(middlewareFn, undefined);
+
+                            return done();
+                        }
+                    );
+                });
+            }
+        );
+    });
+});
+
+if (require.main === module) {
+    Lab.report([lab], { output: process.stdout, progress: 2 });
+}


### PR DESCRIPTION
- Adds pretty thorough unit and integration tests. Call `npm run test` at the root to run all packages' tests.