### PR TITLE
Add compiler middleware tests

### DIFF
--- a/packages/middleware-compiler/test/operation.js
+++ b/packages/middleware-compiler/test/operation.js
@@ -459,6 +459,226 @@ describe('middleware compiler operation', { parallel: true }, () => {
         );
 
         it(
+            'succeeds in running a webtask with a single middleware that reassigns the script to a custom function',
+            (done, onCleanup) => {
+                const script = `module.exports = cb => cb(null, 'This function will be reassigned');`;
+                // Any time the script is reassigned, `req.webtaskContext.compiler.nodejsCompiler` must be decorated with optional compilation.
+                // For more context, see https://github.com/auth0/webtask-userspace/blob/f337550a007bf10d3f2d71395822501008c152dc/packages/middleware-compiler/index.js#L48-L62
+                // and https://github.com/auth0/webtask-userspace/blob/f337550a007bf10d3f2d71395822501008c152dc/packages/middleware-compiler/lib/middleware.js#L36-L39
+                const middleware = `
+                  module.exports = () => (req, res, next) => {
+                    const defaultCompiler = req.webtaskContext.compiler.nodejsCompiler;
+                    const optionallyCompile = (s, cb) => typeof s === 'function' ? cb(null, s) : defaultCompiler(s, cb);
+                    req.webtaskContext.compiler.nodejsCompiler = optionallyCompile;
+                    req.webtaskContext.compiler.script = cb => cb(null, 'OK');
+                    return next();
+                  }
+                `;
+
+                return Helpers.spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanup(server.stop);
+
+                    const middlewareSpecs = [server.baseUrl];
+
+                    return createPipeline(
+                        { script, middlewareSpecs },
+                        (error, webtaskFn) => {
+                            Assert.ifError(error);
+
+                            return invokePipeline(
+                                webtaskFn,
+                                {},
+                                res => {
+                                    Assert.equal(res.statusCode, 200);
+                                    Assert.equal(res.payload, '"OK"');
+
+                                    done();
+                                }
+                            );
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'succeeds in running a webtask with compiler middleware and custom programming model',
+            (done, onCleanup) => {
+                const script = `module.exports = async (context) => 'OK';`;
+                const middleware = `
+                  module.exports = () => (req, res, next) => {
+                    const defaultCompiler = req.webtaskContext.compiler.nodejsCompiler;
+                    const optionallyCompile = (s, cb) => typeof s === 'function' ? cb(null, s) : defaultCompiler(s, cb);
+                    req.webtaskContext.compiler.nodejsCompiler = optionallyCompile;
+                    return req.webtaskContext.compiler.nodejsCompiler(req.webtaskContext.compiler.script, function(compilerError, code) {
+                      if (compilerError) return next(compilerError);
+                      const webtask = require('util').callbackify(code);
+                      req.webtaskContext.compiler.script = (context, cb) => webtask(context, cb);
+                      return next();
+                    });
+                  };
+                `;
+                return Helpers.spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanup(server.stop);
+
+                    const middlewareSpecs = [server.baseUrl];
+
+                    return createPipeline(
+                        { script, middlewareSpecs },
+                        (error, webtaskFn) => {
+                            Assert.ifError(error);
+
+                            return invokePipeline(
+                                webtaskFn,
+                                {},
+                                res => {
+                                    Assert.equal(res.statusCode, 200);
+                                    Assert.equal(res.payload, '"OK"');
+
+                                    done();
+                                }
+                            );
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'succeeds in running a webtask with a compiler followed by multiple middleware functions',
+            (done, onCleanup) => {
+                const script = `module.exports = cb => cb(null, 'OK');`;
+                const middleware = (req, res) => {
+                    res.writeHead(200, {'Content-Type': 'application/javascript'});
+                    const router = {
+                      '/compiler': `
+                        module.exports = () => (req, res, next) => {
+                          const nodejsCompiler = req.webtaskContext.compiler.nodejsCompiler;
+                          const optionallyCompile = (s, cb) => typeof s === 'function' ? cb(null, s) : nodejsCompiler(s, cb);
+                          req.webtaskContext.compiler.nodejsCompiler = optionallyCompile;
+                          return req.webtaskContext.compiler.nodejsCompiler(req.webtaskContext.compiler.script, function(compilerError, webtask) {
+                            if (compilerError) return next(compilerError);
+                            req.webtaskContext.compiler.script = webtask;
+                            return next();
+                          });
+                        };
+                      `,
+                      '/auth': `
+                        module.exports = () => (req, res, next) => {
+                          const isAuthorized = true;
+                          if (!isAuthorized) return next(new Error('Not autorized!'));
+                          return next();
+                        };
+                      `,
+                      '/noop': `module.exports = () => (req, res, next) => next();`
+                    };
+                    res.end(router[req.url]);
+                };
+                return Helpers.spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanup(server.stop);
+
+                    const middlewareSpecs = [
+                        `${server.baseUrl}/compiler`,
+                        `${server.baseUrl}/auth`,
+                        `${server.baseUrl}/noop`,
+                    ];
+
+                    return createPipeline(
+                        { script, middlewareSpecs },
+                        (error, webtaskFn) => {
+                            Assert.ifError(error);
+
+                            return invokePipeline(
+                                webtaskFn,
+                                {},
+                                res => {
+                                    Assert.equal(res.statusCode, 200);
+                                    Assert.equal(res.payload, '"OK"');
+
+                                    done();
+                                }
+                            );
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
+            'succeeds in running a webtask with composed compilers',
+            (done, onCleanup) => {
+                const script = `module.exports = cb => cb(null, 'OK');`;
+                const middleware = (req, res) => {
+                    res.writeHead(200, {'Content-Type': 'application/javascript'});
+                    const router = {
+                      '/compose': `
+                        module.exports = () => (req, res, next) => {
+                          const nodejsCompiler = req.webtaskContext.compiler.nodejsCompiler;
+                          const optionallyCompile = (s, cb) => typeof s === 'function' ? cb(null, s) : nodejsCompiler(s, cb);
+                          req.webtaskContext.compiler.nodejsCompiler = optionallyCompile;
+                          return next();
+                        }
+                      `,
+                      '/promisify': `
+                        module.exports = () => (req, res, next) => {
+                          return req.webtaskContext.compiler.nodejsCompiler(req.webtaskContext.compiler.script, function(compilerError, webtask) {
+                            if (compilerError) return next(compilerError);
+                            req.webtaskContext.compiler.script = require('util').promisify(webtask);
+                            return next();
+                          });
+                        };
+                      `,
+                      '/callbackify': `
+                        module.exports = () => (req, res, next) => {
+                          return req.webtaskContext.compiler.nodejsCompiler(req.webtaskContext.compiler.script, function(compilerError, code) {
+                            if (compilerError) return next(compilerError);
+                            const webtask = require('util').callbackify(code);
+                            req.webtaskContext.compiler.script = (cb) => webtask(cb);
+                            return next();
+                          });
+                        };
+                      `
+                    };
+                    res.end(router[req.url]);
+                };
+                return Helpers.spawnServer(middleware, (error, server) => {
+                    Assert.ifError(error);
+
+                    onCleanup(server.stop);
+
+                    const middlewareSpecs = [
+                        `${server.baseUrl}/compose`,
+                        `${server.baseUrl}/promisify`,
+                        `${server.baseUrl}/callbackify`,
+                    ];
+
+                    return createPipeline(
+                        { script, middlewareSpecs },
+                        (error, webtaskFn) => {
+                            Assert.ifError(error);
+
+                            return invokePipeline(
+                                webtaskFn,
+                                {},
+                                res => {
+                                    Assert.equal(res.statusCode, 200);
+
+                                    done();
+                                }
+                            );
+                        }
+                    );
+                });
+            }
+        );
+
+        it(
             'succeeds in running a webtask with a url-based middleware that intercepts on the response',
             (done, onCleanup) => {
                 const script = `module.exports = cb => cb(null, 'OK');`;


### PR DESCRIPTION
Overview:
---
Adds tests for middleware functions that modify the webtask script.

Motivation:
---
Showcase advanced functionality like compilers or even composable compilers.

Example Middleware:
---
This middleware allows webtasks to export async functions and return their results directly. Notice that the `nodejsCompiler` is decorated with optional compilation, the compiled script is assigned to `req.webtaskContext.compiler.script` and the `next` middleware function is called. Optional compilation is necessary whenever a webtask script is reassigned to a new `Function` object.
```javascript
module.exports = function() {
  const defaultCompiler = req.webtaskContext.compiler.nodejsCompiler;
  const optionallyCompile = (s, cb) => typeof s === 'function' ? cb(null, s) : defaultCompiler(s, cb);
  req.webtaskContext.compiler.nodejsCompiler = optionallyCompile;
  return function(req, res, next) {
    return req.webtaskContext.compiler.nodejsCompiler(req.webtaskContext.compiler.script, function(compilerError, code) {
      if (compilerError) return next(compilerError);
      const webtask = require('util').callbackify(code);
      req.webtaskContext.compiler.script = (context, cb) => webtask(context, cb);
      return next();
    });
  };
};
```

Testing:
---
New tests introduced:
- succeeds in running a webtask with a single middleware that reassigns the script to a custom function
- succeeds in running a webtask with compiler middleware and custom programming model
- succeeds in running a webtask with a compiler followed by multiple middleware functions
- succeeds in running a webtask with composed compilers

Test Output:
---
```
middleware compiler operation
  ✔ 1) succeeds in producing a webtask function (20 ms and 0 assertions)
  ✔ 2) succeeds in producing a webtask function with a middleware (20 ms and 0 assertions)
  ✔ 3) succeeds in producing a webtask function with a middleware and enables debug logging (20 ms and 0 assertions)
  ✔ 4) succeeds in producing a webtask function with a middleware specified as JSON (20 ms and 0 assertions)
  ✔ 5) fails to produce a webtask function with a middleware specified as JSON that is not a valid array (20 ms and 0 assertions)
  pipeline execution
    ✔ 6) responds with an error when the underlying webtask code is invalid javascript (125 ms and 0 assertions)
    ✔ 7) responds with an error when the underlying webtask exports a method that does not conform to the webtask programming model (125 ms and 0 assertions)
    ✔ 8) handles a non-Error error argument in the callback when running a 1ary webtask without middleware (125 ms and 0 assertions)
    ✔ 9) handles objects that cannot be stringified that are passed to the callback when running a 1ary webtask without middleware (125 ms and 0 assertions)
    ✔ 10) succeeds in running a 1ary webtask without middleware (125 ms and 0 assertions)
    ✔ 12) succeeds in running a 2ary webtask without middleware (125 ms and 0 assertions)
    ✔ 17) succeeds in running a 3ary webtask without middleware (125 ms and 0 assertions)
    ✔ 19) succeeds in running a webtask with middleware that intercepts the response (125 ms and 0 assertions)
    ✔ 11) succeeds in running a 1ary webtask without middleware twice in sequence (125 ms and 0 assertions)
    ✔ 18) succeeds in running a webtask with middleware (125 ms and 0 assertions)
    ✔ 13) succeeds in running a 1ary webtask with a payload body, but without middleware (131 ms and 0 assertions)
    ✔ 14) succeeds in running a 2ary webtask with a payload body, but without middleware (131 ms and 0 assertions)
    ✔ 15) responds with an error when running a 2ary webtask with an invalid payload body, but without middleware (131 ms and 0 assertions)
    ✔ 16) succeeds in running a 3ary webtask with a payload body, with the bodyParser.json middleware (131 ms and 0 assertions)
    ✔ 20) succeeds in running a webtask with a url-based middleware that passes on the response (149 ms and 0 assertions)
    ✔ 22) succeeds in running a webtask with compiler middleware and custom programming model (149 ms and 0 assertions)
    ✔ 21) succeeds in running a webtask with a single middleware that reassigns the script to a custom function (149 ms and 0 assertions)
    ✔ 25) succeeds in running a webtask with a url-based middleware that intercepts on the response (149 ms and 0 assertions)
    ✔ 23) succeeds in running a webtask with a compiler followed by multiple middleware functions (157 ms and 0 assertions)
    ✔ 24) succeeds in running a webtask with composed compilers (160 ms and 0 assertions)
middleware spec loader
  ✔ 26) fails to load a non-string spec (0 ms and 0 assertions)
  module specs
    ✔ 27) succeeds loading an npm middleware function (1 ms and 0 assertions)
    ✔ 28) succeeds loading an npm middleware function via export (1 ms and 0 assertions)
    ✔ 29) fails to load a module that is not available (1 ms and 0 assertions)
  url specs
    ✔ 30) succeeds loading a middleware function from a url (13 ms and 0 assertions)
    ✔ 31) fails to load a middleware function from a url whose code does not export a valid middleware function (13 ms and 0 assertions)
    ✔ 32) fails to load a middleware function from a url whose code is not valid javascript (13 ms and 0 assertions)
    ✔ 33) fails to load an middleware from a url returning a 404 error (14 ms and 0 assertions)
middleware spec parser
  ✔ 34) correctly parses a basic module (0 ms and 0 assertions)
  ✔ 35) correctly parses a scoped module (0 ms and 0 assertions)
  ✔ 36) correctly parses a scoped module with an export (0 ms and 0 assertions)
  ✔ 37) throws for a bare scope (0 ms and 0 assertions)


37 tests complete
Test duration: 201 ms
Assertions count: 0 (verbosity: 0.00)
No global variable leaks detected
Coverage: 94.07% (21/354)
index.js missing coverage on line(s): 72, 90, 93, 96, 109, 110, 125, 145, 159, 168, 171, 173
lib/middleware.js missing coverage on line(s): 83, 91, 93, 108, 110
lib/util.js missing coverage on line(s): 145, 151, 165, 166
Linting results: No issues
```