### PR TITLE
Async function and optional compiler middlewares

### DIFF
--- a/packages/async-function-middleware/.eslintrc
+++ b/packages/async-function-middleware/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 6
+    }
+}

--- a/packages/async-function-middleware/README.md
+++ b/packages/async-function-middleware/README.md
@@ -1,0 +1,28 @@
+# Async function middleware
+
+The async function middleware provides a custom programming model which allows a webtask to directly return results in an idiomatic way.
+
+## Usage
+
+To use the async function middleware, you must create a webtask that exports an async function that returns a result:
+
+```javascript
+module.exports = async function (context) {
+  return { hello: context.query.name || 'Anonymous' };
+}
+```
+
+1. Set the `wt-node-dependencies` metadata property to a stringified JSON of an object having `@webtask/middleware-compiler` and `@webtask/async-function-middleware` properties whose values are the latest version of the [@webtask/middleware-compiler](../middleware-compiler) module and this module, respectively. For example:
+
+    ```json
+    {
+      "@webtask/middleware-compiler": "1.5.0",
+      "@webtask/async-function-middleware": "1.0.0"
+    }
+    ```
+
+2. Set the `wt-compiler` metadata property on your webtask to `@webtask/middleware-compiler`.
+
+3. Set (or add to) the `wt-middleware` metadata property of your webtask to contain a comma-separated list containing `@webtask/async-function-middleware`.
+
+4. Issue requests to your webtask

--- a/packages/async-function-middleware/index.js
+++ b/packages/async-function-middleware/index.js
@@ -1,0 +1,18 @@
+'use strict';
+const optionalCompilerMiddleware = require('@webtask/optional-compiler-middleware')();
+const { callbackify } = require('util');
+module.exports = createAsyncFunctionMiddleware;
+
+function createAsyncFunctionMiddleware() {
+  return function asyncFunctionMiddleware(req, res, next) {
+    return optionalCompilerMiddleware(req, res, function() {
+      const { nodejsCompiler, script } = req.webtaskContext.compiler;
+      return nodejsCompiler(script, function(compilerError, code) {
+        if (compilerError) return next(compilerError);
+        const webtask = callbackify(code);
+        req.webtaskContext.compiler.script = (context, cb) => webtask(context, cb);
+        return next();
+      });
+    });
+  };
+}

--- a/packages/async-function-middleware/package.json
+++ b/packages/async-function-middleware/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@webtask/async-function-middleware",
+  "version": "1.0.0",
+  "description": "Webtask middleware that implements an async function programming model",
+  "main": "index.js",
+  "scripts": {
+    "preversion": "npm run test",
+    "test": "lab -cvL"
+  },
+  "keywords": [],
+  "author": "Auth0 Extend Team",
+  "license": "MIT",
+  "peerDependencies": {
+    "@webtask/middleware-compiler": "^1.5.0"
+  },
+  "dependencies": {
+    "@webtask/optional-compiler-middleware": "^1.0.0"
+  },
+  "devDependencies": {
+    "hoek": "^4.2.1",
+    "lab": "^14.3.4",
+    "shot": "^3.4.2"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "tabWidth": 2
+  }
+}

--- a/packages/async-function-middleware/test/lib/helpers.js
+++ b/packages/async-function-middleware/test/lib/helpers.js
@@ -1,0 +1,21 @@
+const Module = require('module');
+const Vm = require('vm');
+
+module.exports = {
+  nodejsCompiler
+};
+
+function nodejsCompiler(script, cb) {
+  try {
+      const wrapper = Module.wrap(script);
+      const wrapperFn = Vm.runInNewContext(wrapper);
+      const exports = {};
+      const module = { exports };
+
+      wrapperFn(exports, require, module, 'async-function-middleware.js', '/');
+
+      return process.nextTick(cb, null, module.exports);
+  } catch (e) {
+      return process.nextTick(cb, e);
+  }
+}

--- a/packages/async-function-middleware/test/operation.js
+++ b/packages/async-function-middleware/test/operation.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const Assert = require('assert');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Shot = require('shot');
+const Helpers = require('./lib/helpers');
+const AsyncFunctionMiddleware = require('../');
+
+const lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+
+module.exports = { lab };
+
+describe('async function middleware', () => {
+    it('succeeds in running a webtask that exports an async function and returns a result', done => {
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+                script: "module.exports = async (context) => 'OK';"
+            }
+        });
+
+        return run({}, (error, webtask) => {
+            Assert.ifError(error);
+
+            webtask({}, (error, result) => {
+                Assert.ifError(error);
+                Assert.equal(result, 'OK');
+
+                return done();
+            });
+        });
+    });
+
+    it('responds with an error when a webtask exports an async function and throws an error', done => {
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+                script: "module.exports = async (context) => { throw new Error('OOPS') };"
+            }
+        });
+
+        return run({}, (error, webtask) => {
+            Assert.ifError(error);
+
+            webtask({}, (error, result) => {
+                Assert(error);
+                Assert.equal(error.message, 'OOPS');
+                Assert.equal(result, undefined);
+
+                return done();
+            });
+        });
+    });
+
+    it('succeeds in running a webtask that returns a promise resolution', done => {
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+                script: "module.exports = (context) => Promise.resolve('OK');"
+            }
+        });
+
+        return run({}, (error, webtask) => {
+            Assert.ifError(error);
+
+            webtask({}, (error, result) => {
+                Assert.ifError(error);
+                Assert.equal(result, 'OK');
+
+                return done();
+            });
+        });
+    });
+
+    it('responds with an error when a webtask returns a promise rejection', done => {
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+                script: "module.exports = (context) => Promise.reject(new Error('OOPS'));"
+            }
+        });
+
+        return run({}, (error, webtask) => {
+            Assert.ifError(error);
+
+            webtask({}, (error, result) => {
+                Assert(error);
+                Assert.equal(error.message, 'OOPS');
+                Assert.equal(result, undefined);
+
+                return done();
+            });
+        });
+    });
+
+    it('responds with an error when the webtask is invalid javascript', done => {
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+                script: "module.exports = This is how it works, right?"
+            }
+        });
+
+        return run({}, (error, webtask) => {
+            Assert(error);
+            Assert.equal(webtask, undefined);
+
+            return done();
+        });
+    });
+});
+
+function createMockRunner(webtaskContext) {
+    if (!webtaskContext) webtaskContext = {};
+
+    const middlewareFn = AsyncFunctionMiddleware();
+
+    return function run(requestOptions, next) {
+        const defaultWebtaskContext = {
+            headers: requestOptions.headers || {}
+        };
+
+        const dispatchFn = (req, res) => {
+            req.webtaskContext = Hoek.applyToDefaults(
+                defaultWebtaskContext,
+                webtaskContext
+            );
+
+            return middlewareFn(req, res, (middlewareError) => {
+                if (middlewareError) return next(middlewareError);
+                next(null, req.webtaskContext.compiler.script);
+            });
+        };
+
+        const defaultRequestOptions = { url: '/' };
+
+        return Shot.inject(
+            dispatchFn,
+            Hoek.applyToDefaults(defaultRequestOptions, requestOptions),
+            res => Assert.fail(res, null, 'Unexpected response')
+        );
+    };
+}
+
+if (require.main === module) {
+    Lab.report([lab], { output: process.stdout, progress: 2 });
+}

--- a/packages/bearer-auth-middleware/README.md
+++ b/packages/bearer-auth-middleware/README.md
@@ -9,7 +9,7 @@ To use the bearer auth middleware requires encoding a shared secret in the `wt-a
 1. Set the `wt-node-dependencies` metadata property to the stringified JSON of an object having `@webtask/middleware-compiler` and `@webtask/bearer-auth-middleware` properties whose values are the latest version of the [@webtask/middleware-compiler](../middleware-compiler) module and this module, respectively.
 
     ```json
-    {"@webtask/middleware-compiler":"1.1.0","@webtas/bearer-auth-middleware":"1.1.0"}
+    {"@webtask/middleware-compiler":"1.1.0","@webtask/bearer-auth-middleware":"1.1.0"}
     ```
 
 2. Set the `wt-compiler` metadata property on your webtask to `@webtask/middleware-compiler`.

--- a/packages/cron-auth-middleware/README.md
+++ b/packages/cron-auth-middleware/README.md
@@ -9,7 +9,7 @@ To use the cron auth middleware leverages the fact that the Webtask cron daemon 
 1. Set the `wt-node-dependencies` metadata property to the stringified JSON of an object having `@webtask/middleware-compiler` and `@webtask/cron-auth-middleware` properties whose values are the latest version of the [@webtask/middleware-compiler](../middleware-compiler) module and this module, respectively.
 
     ```json
-    {"@webtask/middleware-compiler":"1.1.0","@webtas/cron-auth-middleware":"1.1.0"}
+    {"@webtask/middleware-compiler":"1.1.0","@webtask/cron-auth-middleware":"1.1.0"}
     ```
 
 2. Set the `wt-compiler` metadata property on your webtask to `@webtask/middleware-compiler`.

--- a/packages/optional-compiler-middleware/.eslintrc
+++ b/packages/optional-compiler-middleware/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 6
+    }
+}

--- a/packages/optional-compiler-middleware/README.md
+++ b/packages/optional-compiler-middleware/README.md
@@ -1,0 +1,20 @@
+# Optional compiler middleware
+
+The optional compiler middleware enables advanced middleware usage such as implementing compilers as middleware or even composable compilers. [`@webtask/middleware-compiler`](../middleware-compiler) plays a fundamental role in enabling middleware functions and one of its core assumptions is that the underlying webtask script (located at `req.webtaskContext.compiler.script`) is a string. It would be convenient to be able to reassign the webtask script to a compiled `Function` object when implementing a compiler. Unfortunately, this breaks the assumption made by `@webtask/middleware-compiler` (or even other userspace middleware functions) that it is safe to call `nodejsCompiler` on `req.webtaskContext.compiler.script`. This middleware decorates the `nodejsCompiler` with optional compilation based on the type of the webtask script.
+
+## Usage
+
+1. Set the `wt-node-dependencies` metadata property to the stringified JSON of an object having `@webtask/middleware-compiler` and `@webtask/optional-compiler-middleware` properties whose values are the latest version of the [@webtask/middleware-compiler](../middleware-compiler) module and this module, respectively.
+
+    ```json
+    {
+      "@webtask/middleware-compiler": "1.5.0",
+      "@webtask/optional-compiler-middleware": "1.0.0"
+    }
+    ```
+
+2. Set the `wt-compiler` metadata property on your webtask to `@webtask/middleware-compiler`.
+
+3. Set (or add to) the `wt-middleware` metadata property of your webtask to contain a comma-separated list containing `@webtask/optional-compiler-middleware`.
+
+4. Issue requests to your webtask

--- a/packages/optional-compiler-middleware/index.js
+++ b/packages/optional-compiler-middleware/index.js
@@ -1,0 +1,15 @@
+'use strict';
+const hasOptionalCompilation = Symbol('hasOptionalCompilation');
+module.exports = createOptionalCompilerMiddleware;
+
+function createOptionalCompilerMiddleware() {
+  return function optionalCompilerMiddleware(req, res, next) {
+    const defaultCompiler = req.webtaskContext.compiler.nodejsCompiler;
+    if (req.webtaskContext.compiler[hasOptionalCompilation]) return next();
+    req.webtaskContext.compiler[hasOptionalCompilation] = true;
+    req.webtaskContext.compiler.nodejsCompiler = function(script, cb) {
+      typeof script === 'function' ? cb(null, script) : defaultCompiler(script, cb);
+    };
+    return next();
+  };
+}

--- a/packages/optional-compiler-middleware/package.json
+++ b/packages/optional-compiler-middleware/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@webtask/optional-compiler-middleware",
+  "version": "1.0.0",
+  "description": "Webtask middleware that decorates the nodejsCompiler with optional compilation",
+  "main": "index.js",
+  "scripts": {
+    "preversion": "npm run test",
+    "test": "lab -cvL"
+  },
+  "keywords": [],
+  "author": "Auth0 Extend Team",
+  "license": "MIT",
+  "peerDependencies": {
+    "@webtask/middleware-compiler": "^1.5.0"
+  },
+  "devDependencies": {
+    "hoek": "^4.2.1",
+    "lab": "^14.3.4",
+    "shot": "^3.4.2"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "tabWidth": 2
+  }
+}

--- a/packages/optional-compiler-middleware/test/lib/helpers.js
+++ b/packages/optional-compiler-middleware/test/lib/helpers.js
@@ -1,0 +1,21 @@
+const Module = require('module');
+const Vm = require('vm');
+
+module.exports = {
+  nodejsCompiler
+};
+
+function nodejsCompiler(script, cb) {
+  try {
+      const wrapper = Module.wrap(script);
+      const wrapperFn = Vm.runInNewContext(wrapper);
+      const exports = {};
+      const module = { exports };
+
+      wrapperFn(exports, require, module, 'optional-compiler-middleware.js', '/');
+
+      return process.nextTick(cb, null, module.exports);
+  } catch (e) {
+      return process.nextTick(cb, e);
+  }
+}

--- a/packages/optional-compiler-middleware/test/operation.js
+++ b/packages/optional-compiler-middleware/test/operation.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const Assert = require('assert');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Shot = require('shot');
+const Helpers = require('./lib/helpers');
+const OptionalCompilerMiddleware = require('../');
+
+const lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+
+module.exports = { lab };
+
+describe('optional compiler middleware', () => {
+    it('succeeds in decorating nodejsCompiler with optional compilation', done => {
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+            }
+        });
+
+        return run({}, (error, nodejsCompiler) => {
+            Assert.ifError(error);
+            Assert.equal(typeof nodejsCompiler, 'function');
+            Assert.notDeepEqual(nodejsCompiler, Helpers.nodejsCompiler);
+            const compilerChecksType = nodejsCompiler.toString().includes(`typeof script === 'function'`);
+            Assert.ok(compilerChecksType);
+
+            return done();
+        });
+    });
+
+    it('succeeds in skipping if nodejsCompiler already has optional compilation', done => {
+        const req = { webtaskContext: { compiler: { nodejsCompiler: Helpers.nodejsCompiler } } };
+        OptionalCompilerMiddleware()(req, {}, () => {
+            Assert.notDeepEqual(req.webtaskContext.compiler.nodejsCompiler, Helpers.nodejsCompiler);
+            const compilerReference = req.webtaskContext.compiler.nodejsCompiler;
+
+            OptionalCompilerMiddleware()(req, {}, error => {
+                Assert.ifError(error);
+                Assert.equal(typeof req.webtaskContext.compiler.nodejsCompiler, 'function');
+                Assert.deepEqual(req.webtaskContext.compiler.nodejsCompiler, compilerReference);
+
+                return done();
+            });
+        });
+    });
+
+    it('succeeds in optionally compiling a string', done => {
+        const script = `module.exports = (cb) => cb(null, 'OK');`;
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+            }
+        });
+
+        return run({}, (middlewareError, nodejsCompiler) => {
+            Assert.ifError(middlewareError);
+
+            nodejsCompiler(script, (compilerError, webtask) => {
+                Assert.ifError(compilerError)
+                Assert.equal(typeof webtask, 'function');
+
+                return done();
+            });
+
+        });
+    });
+
+    it('succeeds in optionally compiling a function', done => {
+        const script = (cb) => cb(null, 'OK');
+        const run = createMockRunner({
+            compiler: {
+                nodejsCompiler: Helpers.nodejsCompiler,
+            }
+        });
+
+        return run({}, (middlewareError, nodejsCompiler) => {
+            Assert.ifError(middlewareError);
+
+            nodejsCompiler(script, (compilerError, webtask) => {
+              Assert.ifError(compilerError)
+              Assert.equal(typeof webtask, 'function');
+
+              return done();
+          });
+        });
+    });
+});
+
+function createMockRunner(webtaskContext) {
+    if (!webtaskContext) webtaskContext = {};
+
+    const middlewareFn = OptionalCompilerMiddleware();
+
+    return function run(requestOptions, next) {
+        const defaultWebtaskContext = {
+            headers: requestOptions.headers || {}
+        };
+
+        const dispatchFn = (req, res) => {
+            req.webtaskContext = Hoek.applyToDefaults(
+                defaultWebtaskContext,
+                webtaskContext
+            );
+
+            return middlewareFn(req, res, (middlewareError) => {
+                if (middlewareError) return next(middlewareError);
+                return next(null, req.webtaskContext.compiler.nodejsCompiler);
+            });
+        };
+
+        const defaultRequestOptions = { url: '/' };
+
+        return Shot.inject(
+            dispatchFn,
+            Hoek.applyToDefaults(defaultRequestOptions, requestOptions),
+            res => Assert.fail(res, null, 'Unexpected response')
+        );
+    };
+}
+
+if (require.main === module) {
+    Lab.report([lab], { output: process.stdout, progress: 2 });
+}


### PR DESCRIPTION
Context:
---
https://auth0team.atlassian.net/browse/EX-1265
https://github.com/auth0/webtask-bundle/issues/31
https://github.com/auth0/extend-editor-assets/pull/5

Adding full async function support (the ability to directly return results from async functions) and, more generally, promise support to webtasks has called to attention the need for optional compilation. Compilation in this context refers to the use of the `nodejsCompiler` within middleware functions and specifically within the `defaultMiddleware` defined by `@webtask/middleware-compiler`.

Up to this point, it has been (relatively) safe to assume that the script exposed at `req.webtaskContext.compiler.script` would be a string and could be passed to `req.webtaskContext.compiler.nodejsCompiler`.

However, it is often desirable when authoring middleware compilers to reassign the webtask script to a compiled `Function` object. This breaks the aforementioned assumptions of `middleware-compiler` and other userspace middleware compilers.

This issue inspired the idea of decorating the `nodejsCompiler` with optional compilation. 
```javascript
const defaultCompiler = req.webtaskContext.compiler.nodejsCompiler;
req.webtaskContext.compiler.nodejsCompiler = function(script, cb) {
  typeof script === 'function' ? cb(null, script) : defaultCompiler(script, cb);
};
```

It has been decided to make this functionality available as built-in middleware within the editor. This allows users to easily pull in the required `@webtask` modules and avoid requesting the middleware scripts from a CDN with every webtask execution.

Testing:
---
```
optional compiler middleware
  ✔ 1) succeeds in decorating nodejsCompiler with optional compilation (5 ms and 0 assertions)
  ✔ 2) succeeds in skipping if nodejsCompiler already has optional compilation (1 ms and 0 assertions)
  ✔ 3) succeeds in optionally compiling a string (2 ms and 0 assertions)
  ✔ 4) succeeds in optionally compiling a function (0 ms and 0 assertions)

async function middleware
  ✔ 1) succeeds in running a webtask that exports an async function and returns a result (13 ms and 0 assertions)
  ✔ 2) responds with an error when a webtask exports an async function and throws an error (2 ms and 0 assertions)
  ✔ 3) succeeds in running a webtask that returns a promise resolution (1 ms and 0 assertions)
  ✔ 4) responds with an error when a webtask returns a promise rejection (1 ms and 0 assertions)
  ✔ 5) responds with an error when the webtask is invalid javascript (1 ms and 0 assertions)


9 tests complete
Test duration: 36 ms
Assertions count: 0 (verbosity: 0.00)
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```

Other Considerations:
---
- `optional-compiler-middleware` checks if the `nodejsCompiler` has already been decorated before wrapping the `defaultCompiler`. This means it can be included as a direct dependency of any compiler as middleware package without worrying about rewrapping the `nodejsCompiler` several times.
- Prettier was included in the two new packages.
- Simple typos were fixed in the `bearer-auth-middleware` and `cron-auth-middleware` READMEs.
- Originally, a test was created for `async-function-middleware` that ensured an error was thrown if an invalid programming model was used. However, this required wrapping the call site of the callbackified webtask with a try catch and was reimplementing functionality provided by the runtime. Thus, the choice was made to remove the test as it seemed to be outside of the purview of the module.